### PR TITLE
ci: update semantic release action to pull from ghcr

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,7 +31,7 @@ jobs:
 
       # Continuous Delivery Pipeline --
 
-      - uses: codfish/semantic-release-action@325861fef675efe314060ac325a61dde726ec607
+      - uses: docker://ghcr.io/codfish/semantic-release-action:v1.6.2
         name: Semantic Release
         id: semantic
         env:


### PR DESCRIPTION
Improves workflow run times by ~45s. Leverages changes here codfish/semantic-release-action#156

See codfish/semantic-release-action#142 for more context